### PR TITLE
feat(themes): add tab border radius

### DIFF
--- a/docs/theme-reference.md
+++ b/docs/theme-reference.md
@@ -71,6 +71,14 @@ This document provides a comprehensive list of all CSS variables available for t
 | `--ttabs-drop-target-outline` | Drop target outline style | `2px dashed rgba(74, 108, 247, 0.5)` |
 | `--ttabs-split-indicator-color` | Split indicator color | `rgba(74, 108, 247, 0.1)` |
 
+## Border Radius
+| Variable | Description | Default Value |
+| --- | --- | --- |
+| `--ttabs-border-top-left-radius` | Tabs top left border radius | `#666` |
+| `--ttabs-border-top-right-radius` | Tabs top right border radius | `#666` |
+| `--ttabs-border-bottom-left-radius` | Tabs bottom left border radius | `#666` |
+| `--ttabs-border-bottom-right-radius` | Tabs bottom right border radius | `#666` |
+
 ## Element Classes
 
 You can also customize CSS classes for different elements using the `classes` property in your theme:

--- a/packages/ttabs/src/lib/ttabs/components/TilePanel.svelte
+++ b/packages/ttabs/src/lib/ttabs/components/TilePanel.svelte
@@ -821,8 +821,10 @@
       display: flex;
       align-items: center;
       color: var(--ttabs-tab-text-color);
-      border-top-left-radius: none;
-      border-top-right-radius: none;
+      border-top-left-radius: var(--ttabs-border-top-left-radius);
+      border-top-right-radius: var(--ttabs-border-top-right-radius);
+      border-bottom-left-radius: var(-ttabs-border-bottom-left-radius);
+      border-bottom-right-radius: var(-ttabs-border-bottom-right-radius);
     }
 
     .ttabs-tab-title {

--- a/packages/ttabs/src/lib/ttabs/types/theme-types.ts
+++ b/packages/ttabs/src/lib/ttabs/types/theme-types.ts
@@ -65,8 +65,10 @@ export type TtabsCssVariables = {
   '--ttabs-drop-indicator-offset': string;
   
   // Border radius
-  '--ttabs-border-radius': string;
-  '--ttabs-border-radius-sm': string;
+  '--ttabs-border-top-left-radius': string;
+  '--ttabs-border-top-right-radius': string;
+  '--ttabs-border-bottom-left-radius': string;
+  '--ttabs-border-bottom-right-radius': string;
 }
 
 /**
@@ -198,8 +200,11 @@ export const DEFAULT_THEME: TtabsTheme = {
     '--ttabs-drop-indicator-offset': '-2px',
     
     // Border radius
-    '--ttabs-border-radius': '0',
-    '--ttabs-border-radius-sm': '0',
+    '--ttabs-border-top-left-radius': '0',
+    '--ttabs-border-top-right-radius': '0',
+    '--ttabs-border-bottom-left-radius': '0',
+    '--ttabs-border-bottom-right-radius': '0',
+
     
     // Controls
     '--ttabs-show-close-button': 'flex', // Show close buttons by default


### PR DESCRIPTION
adds four css variables

'--ttabs-border-top-left-radius'
'--ttabs-border-top-right-radius'
'--ttabs-border-bottom-left-radius'
'--ttabs-border-bottom-right-radius'

and removes two unused css variables that had no effect

'border-top-left-radius'
'border-top-right-radius'

even though the variables were previously unused, it may be worthwhile to keep them around in the type definition
to avoid breaking changes for users. please let me know if breaking changes are acceptable here or if I should keep them in the TtabsCssVariables type